### PR TITLE
Log runtime information for Eastwood process

### DIFF
--- a/src/main/java/org/sonar/plugins/clojure/sensors/eastwood/EastwoodIssueParser.java
+++ b/src/main/java/org/sonar/plugins/clojure/sensors/eastwood/EastwoodIssueParser.java
@@ -13,6 +13,17 @@ public class EastwoodIssueParser {
 
     private EastwoodIssueParser() {}
 
+    public static String parseRuntimeInfo(CommandStreamConsumer output) {
+        if (output != null) {
+            List<String> lines = output.getData();
+            if (lines.size() > 0) {
+                // Remove the "== " prefix in eastwood's output
+                return lines.get(0).substring(3);
+            }
+        }
+        return null;
+    }
+
     public static List<Issue> parse(CommandStreamConsumer output) {
         List<Issue> issues = new ArrayList<>();
 

--- a/src/main/java/org/sonar/plugins/clojure/sensors/eastwood/EastwoodSensor.java
+++ b/src/main/java/org/sonar/plugins/clojure/sensors/eastwood/EastwoodSensor.java
@@ -78,8 +78,14 @@ public class EastwoodSensor implements Sensor {
         LOG.info("Running Eastwood");
         CommandStreamConsumer stdOut = this.commandRunner.run(LEIN_COMMAND, EASTWOOD_COMMAND);
 
-        List<Issue> issues = EastwoodIssueParser.parse(stdOut);
+        String info = EastwoodIssueParser.parseRuntimeInfo(stdOut);
+        if (info != null) {
+            LOG.info("Ran " + info);
+        } else {
+            LOG.warn("Eastwood resulted in empty output");
+        }
 
+        List<Issue> issues = EastwoodIssueParser.parse(stdOut);
         LOG.info("Saving issues");
         for (Issue issue : issues) {
             saveIssue(issue, context);

--- a/src/test/java/org/sonar/plugins/clojure/sensors/eastwood/EastwoodIssueParserTest.java
+++ b/src/test/java/org/sonar/plugins/clojure/sensors/eastwood/EastwoodIssueParserTest.java
@@ -8,6 +8,7 @@ import org.sonar.plugins.clojure.sensors.Issue;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 public class EastwoodIssueParserTest {
@@ -45,4 +46,28 @@ public class EastwoodIssueParserTest {
         assertThat(issues.size(), is(0));
     }
 
+    @Test
+    public void testParseRuntimeInfoForNonEmptyOutput() {
+        CommandStreamConsumer output = new CommandStreamConsumer();
+        output.consumeLine("== Eastwood 0.2.5 Clojure 1.8.0 JVM 1.8.0_121");
+
+        String info = EastwoodIssueParser.parseRuntimeInfo(output);
+        assertThat(info, is("Eastwood 0.2.5 Clojure 1.8.0 JVM 1.8.0_121"));
+    }
+
+    @Test
+    public void testParseRuntimeInfoForEmptyOutput() {
+        CommandStreamConsumer output = new CommandStreamConsumer();
+        String info = EastwoodIssueParser.parseRuntimeInfo(output);
+        assertNull(info);
+    }
+
+    @Test(expected = StringIndexOutOfBoundsException.class)
+    public void testParseRuntimeInfoForInvalidOutput() {
+        CommandStreamConsumer output = new CommandStreamConsumer();
+        output.consumeLine("==");
+        // First line of the output is less than 3 chars, so substring will result in error. Keeping this exception
+        // unhandled in order to fail fast in case Eastwood's output changes in future
+        EastwoodIssueParser.parseRuntimeInfo(output);
+    }
 }


### PR DESCRIPTION
In this commit, we are having the sonar-scanner process log
runtime information for the eastwood process eg. versions of Eastwood,
Clojure and JVM.

This info is included in the Eastwood output as the first line. We are
just extracting it from stdout and logging it. The log level is INFO
as this info can be handy for verifying that eastwood is being run on
the correct environment.