### PR TITLE
Check if kibit is disabled before running it

### DIFF
--- a/src/main/java/org/sonar/plugins/clojure/sensors/kibit/KibitSensor.java
+++ b/src/main/java/org/sonar/plugins/clojure/sensors/kibit/KibitSensor.java
@@ -37,9 +37,10 @@ public class KibitSensor extends AbstractSensor implements Sensor {
 
     @Override
     public void execute(SensorContext context) {
-        LOG.info("Running Kibit");
-        CommandStreamConsumer stdOut = this.commandRunner.run(LEIN_COMMAND, KIBIT_COMMAND);
         if (!checkIfPluginIsDisabled(context, ClojureProperties.KIBIT_DISABLED)) {
+            LOG.info("Running Kibit");
+            CommandStreamConsumer stdOut = this.commandRunner.run(LEIN_COMMAND, KIBIT_COMMAND);
+
             if (isLeinInstalled(stdOut.getData()) && isPluginInstalled(stdOut.getData(), KIBIT_COMMAND)){
 
                 List<Issue> issues = KibitIssueParser.parse(stdOut);


### PR DESCRIPTION
Disabling kibit with `sonar.clojure.kibit.disabled=true` did not work, as it was started before checking whether it was disabled. Moved the run command inside the if clause that checks whether kibit is disabled.