### PR TITLE
Added ability to pass eastwood options

### DIFF
--- a/src/main/java/org/sonar/plugins/clojure/sensors/CommandRunner.java
+++ b/src/main/java/org/sonar/plugins/clojure/sensors/CommandRunner.java
@@ -14,7 +14,9 @@ public class CommandRunner {
         CommandStreamConsumer stdErr = new CommandStreamConsumer();
         Command cmd = Command.create(command);
         for (String arg: arguments) {
-            cmd.addArgument(arg);
+            if (arg != null) {
+                cmd.addArgument(arg);
+            }
         }
         CommandExecutor.create().execute(cmd, stdOut, stdErr, TIMEOUT);
         return stdOut;

--- a/src/main/java/org/sonar/plugins/clojure/sensors/eastwood/EastwoodSensor.java
+++ b/src/main/java/org/sonar/plugins/clojure/sensors/eastwood/EastwoodSensor.java
@@ -32,8 +32,6 @@ public class EastwoodSensor extends AbstractSensor implements Sensor {
     }
 
 
-
-
     @Override
     public void describe(SensorDescriptor descriptor) {
         descriptor.name("SonarClojure")
@@ -43,11 +41,11 @@ public class EastwoodSensor extends AbstractSensor implements Sensor {
 
     @Override
     public void execute(SensorContext context) {
-
         if (!checkIfPluginIsDisabled(context, ClojureProperties.EASTWOOD_DISABLED)) {
             LOG.info("Clojure project detected");
             LOG.info("Running Eastwood");
-            CommandStreamConsumer stdOut = this.commandRunner.run(LEIN_COMMAND, EASTWOOD_COMMAND);
+            String options = context.config().get(ClojureProperties.EASTWOOD_OPTIONS).orElse(null);
+            CommandStreamConsumer stdOut = this.commandRunner.run(LEIN_COMMAND, EASTWOOD_COMMAND, options);
             if (isLeinInstalled(stdOut.getData()) && isPluginInstalled(stdOut.getData(), EASTWOOD_COMMAND)){
                 String info = EastwoodIssueParser.parseRuntimeInfo(stdOut);
                 if (info != null) {
@@ -57,7 +55,7 @@ public class EastwoodSensor extends AbstractSensor implements Sensor {
                 }
 
                 List<Issue> issues = EastwoodIssueParser.parse(stdOut);
-                LOG.info("Saving issues");
+                LOG.info("Saving issues " + issues.size());
                 for (Issue issue : issues) {
                     saveIssue(issue, context);
                 }
@@ -65,7 +63,5 @@ public class EastwoodSensor extends AbstractSensor implements Sensor {
         } else {
             LOG.info ("Eastwood plugin is disabled");
         }
-
     }
-
 }

--- a/src/main/java/org/sonar/plugins/clojure/settings/ClojureProperties.java
+++ b/src/main/java/org/sonar/plugins/clojure/settings/ClojureProperties.java
@@ -12,6 +12,7 @@ public class ClojureProperties {
     public static final String FILE_SUFFIXES_DEFAULT_VALUE = "clj,cljs,cljc";
     public static final String ANCIENT_CLJ_DISABLED = "sonar.clojure.ancient-clj.disabled";
     public static final String EASTWOOD_DISABLED = "sonar.clojure.eastwood.disabled";
+    public static final String EASTWOOD_OPTIONS = "sonar.clojure.eastwood.options";
     public static final String LEIN_NVD_DISABLED = "sonar.clojure.lein-nvd.disabled";
     public static final String LEIN_NVD_JSON_OUTPUT_LOCATION = "sonar.clojure.lein-nvd.json-output-location";
     public static final String MAIN_CATEGORY = "ClojureLanguage";
@@ -24,6 +25,7 @@ public class ClojureProperties {
     public static List<PropertyDefinition> getProperties() {
         return asList(getFileSuffixProperty(),
                 getEastwoodDisabledProperty(),
+                getEastwoodOptionsProperty(),
                 getAncientCljDisabledProperty(),
                 getCloverageDisabledProperty(),
                 getCloverageJsonOutputLocation(),
@@ -48,6 +50,16 @@ public class ClojureProperties {
                 .defaultValue("false")
                 .name("Eastwood sensor disabling")
                 .description("Set true to disable Eastwood sensor.")
+                .build();
+    }
+
+    public static PropertyDefinition getEastwoodOptionsProperty() {
+        return PropertyDefinition.builder(EASTWOOD_OPTIONS)
+                .category(MAIN_CATEGORY)
+                .subCategory("Sensors")
+                .defaultValue(null)
+                .name("Eastwood sensor options")
+                .description("Provide string of options for eastwood plugin (e.g {:continue-on-exception true})")
                 .build();
     }
 

--- a/src/test/java/org/sonar/plugins/clojure/sensors/eastwood/EastwoodSensorTest.java
+++ b/src/test/java/org/sonar/plugins/clojure/sensors/eastwood/EastwoodSensorTest.java
@@ -1,6 +1,7 @@
 package org.sonar.plugins.clojure.sensors.eastwood;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -73,7 +74,9 @@ public class EastwoodSensorTest {
         CommandStreamConsumer stdOut = new CommandStreamConsumer();
         stdOut.consumeLine("file.clj:1:0:issue-1:description-1");
         stdOut.consumeLine("file.clj:2:0:issue-2:description-2");
-        Mockito.when(commandRunner.run("lein", "eastwood")).thenReturn(stdOut);
+        String ignoredOptions = null;
+        Mockito.when(commandRunner.run("lein", "eastwood", ignoredOptions))
+                .thenReturn(stdOut);
 
         EastwoodSensor eastwoodSensor = new EastwoodSensor(commandRunner);
         eastwoodSensor.execute(context);

--- a/src/test/java/org/sonar/plugins/clojure/settings/ClojurePropertiesTest.java
+++ b/src/test/java/org/sonar/plugins/clojure/settings/ClojurePropertiesTest.java
@@ -23,7 +23,7 @@ public class ClojurePropertiesTest {
     @Test
     public void testGetProperties() {
         List<PropertyDefinition> propertyDefinitions = ClojureProperties.getProperties();
-        assertThat(propertyDefinitions.size(), is(8));
+        assertThat(propertyDefinitions.size(), is(9));
         assertThat(propertyDefinitions.get(0).key(), is("sonar.clojure.file.suffixes"));
 
     }

--- a/start-sonarqube.sh
+++ b/start-sonarqube.sh
@@ -2,7 +2,7 @@
 set -eu
 ./mvnw clean package
 docker build . --tag sonarqube_local_image
-docker rm -f sonarqube_local_test
-docker run --name sonarqube_local_test  -p 9000:9000 sonarqube_local_image
+docker rm -f sonarqube_local_image
+docker run --name sonarqube_local_image  -p 9000:9000 sonarqube_local_image
 
 


### PR DESCRIPTION
- Now you can pass eastwood options using property `sonar.clojure.eastwood.options`
- Added failsafe behavior during saving issues