### PR TITLE
Fix Parse newer dependency check json report

### DIFF
--- a/src/main/java/org/sonar/plugins/clojure/sensors/leinnvd/LeinNvdParser.java
+++ b/src/main/java/org/sonar/plugins/clojure/sensors/leinnvd/LeinNvdParser.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.Gson;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 
@@ -30,10 +31,12 @@ public class LeinNvdParser {
                 JsonArray dependencyVulnerabilities = dependency.get("vulnerabilities").getAsJsonArray();
                 for (JsonElement dependencyVulnerability: dependencyVulnerabilities) {
                     JsonObject dependencyVulnerabilityObject = dependencyVulnerability.getAsJsonObject();
+                    JsonArray cwesArray = dependencyVulnerabilityObject.getAsJsonArray("cwes");
+                    String[] cwes = new Gson().fromJson(cwesArray, String[].class);
                     Vulnerability v = new Vulnerability()
                             .setName(dependencyVulnerabilityObject.getAsJsonPrimitive("name").getAsString())
                             .setSeverity(dependencyVulnerabilityObject.getAsJsonPrimitive("severity").getAsString())
-                            .setCwe(dependencyVulnerabilityObject.getAsJsonPrimitive("cwe").getAsString())
+                            .setCwes(String.join(",", cwes))
                             .setDescription(dependencyVulnerabilityObject.getAsJsonPrimitive("description").getAsString())
                             .setFileName(dependency.getAsJsonPrimitive("fileName").getAsString());
                     vulnerabilities.add(v);

--- a/src/main/java/org/sonar/plugins/clojure/sensors/leinnvd/LeinNvdSensor.java
+++ b/src/main/java/org/sonar/plugins/clojure/sensors/leinnvd/LeinNvdSensor.java
@@ -74,7 +74,7 @@ public class LeinNvdSensor extends AbstractSensor implements Sensor {
                         .newLocation()
                         .on(projectFile)
                         .message(v.getName()
-                                + ";" + v.getCwe()
+                                + ";" + v.getCwes()
                                 + ";" + v.getFileName())
                         .at(projectFile.selectLine(1));
                 newIssue.at(primaryLocation);

--- a/src/main/java/org/sonar/plugins/clojure/sensors/leinnvd/Vulnerability.java
+++ b/src/main/java/org/sonar/plugins/clojure/sensors/leinnvd/Vulnerability.java
@@ -5,7 +5,7 @@ import java.util.Objects;
 public class Vulnerability {
     private String name;
     private String severity;
-    private String cwe;
+    private String cwes;
     private String description;
     private String fileName;
 
@@ -27,8 +27,8 @@ public class Vulnerability {
         return this;
     }
 
-    public String getCwe() {
-        return cwe;
+    public String getCwes() {
+        return cwes;
     }
 
     @Override
@@ -36,7 +36,7 @@ public class Vulnerability {
         return "Vulnerability{" +
                 "name='" + name + '\'' +
                 ", severity='" + severity + '\'' +
-                ", cwe='" + cwe + '\'' +
+                ", cwes='" + cwes + '\'' +
                 ", Description='" + description + '\'' +
                 ", fileName='" + fileName + '\'' +
                 '}';
@@ -49,14 +49,14 @@ public class Vulnerability {
         Vulnerability that = (Vulnerability) o;
         return Objects.equals(getName(), that.name) &&
                 Objects.equals(getSeverity(), that.severity) &&
-                Objects.equals(getCwe(), that.cwe) &&
+                Objects.equals(getCwes(), that.cwes) &&
                 Objects.equals(getDescription(), that.description) &&
                 Objects.equals(getFileName(), that.fileName);
     }
 
 
-    public Vulnerability setCwe(String cwe) {
-        this.cwe = cwe;
+    public Vulnerability setCwes(String cwes) {
+        this.cwes = cwes;
         return this;
     }
 
@@ -66,7 +66,7 @@ public class Vulnerability {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, severity, cwe, description, fileName);
+        return Objects.hash(name, severity, cwes, description, fileName);
     }
 
     public Vulnerability setDescription(String description) {

--- a/src/test/java/org/sonar/plugins/clojure/language/ClojureSonarWayProfileTest.java
+++ b/src/test/java/org/sonar/plugins/clojure/language/ClojureSonarWayProfileTest.java
@@ -3,7 +3,6 @@ package org.sonar.plugins.clojure.language;
 import org.junit.Before;
 import org.junit.Test;
 import org.sonar.api.server.profile.BuiltInQualityProfilesDefinition;
-import org.sonar.plugins.clojure.language.ClojureSonarWayProfile;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/org/sonar/plugins/clojure/sensors/leinnvd/LeinNvdParserTest.java
+++ b/src/test/java/org/sonar/plugins/clojure/sensors/leinnvd/LeinNvdParserTest.java
@@ -24,17 +24,17 @@ public class LeinNvdParserTest {
         List<Vulnerability> expected = new ArrayList<>();
         expected.addAll(asList(
                 new Vulnerability()
-                        .setName("CVE-2017-7656")
-                        .setSeverity("Medium")
-                        .setCwe("CWE-284 Improper Access Control")
-                        .setDescription("In Eclipse Jetty, versions 9.2.x and older, 9.3.x (all configurations), and 9.4.x (non-default configuration with RFC2616 compliance enabled), HTTP/0.9 is handled poorly. An HTTP/1 style request line (i.e. method space URI space version) that declares a version of HTTP/0.9 was accepted and treated as a 0.9 request. If deployed behind an intermediary that also accepted and passed through the 0.9 version (but did not act on it), then the response sent could be interpreted by the intermediary as HTTP/1 headers. This could be used to poison the cache if the server allowed the origin client to generate arbitrary content in the response.")
-                        .setFileName("jetty-util-9.2.21.v20170120.jar"),
+                        .setName("CVE-2018-5968")
+                        .setSeverity("HIGH")
+                        .setCwes("CWE-502,CWE-184")
+                        .setDescription("FasterXML jackson-databind through 2.8.11 and 2.9.x through 2.9.3 allows unauthenticated remote code execution because of an incomplete fix for the CVE-2017-7525 and CVE-2017-17485 deserialization flaws. This is exploitable via two different gadgets that bypass a blacklist.")
+                        .setFileName("jackson-databind-2.9.3.jar"),
                 new Vulnerability()
-                        .setName("CVE-2017-7657")
-                        .setSeverity("High")
-                        .setCwe("CWE-190 Integer Overflow or Wraparound")
-                        .setDescription("In Eclipse Jetty, versions 9.2.x and older, 9.3.x (all configurations), and 9.4.x (non-default configuration with RFC2616 compliance enabled), transfer-encoding chunks are handled poorly. The chunk length parsing was vulnerable to an integer overflow. Thus a large chunk size could be interpreted as a smaller chunk size and content sent as chunk body could be interpreted as a pipelined request. If Jetty was deployed behind an intermediary that imposed some authorization and that intermediary allowed arbitrarily large chunks to be passed on unchanged, then this flaw could be used to bypass the authorization imposed by the intermediary as the fake pipelined request would not be interpreted by the intermediary as a request.")
-                        .setFileName("jetty-util-9.2.21.v20170120.jar")));
+                        .setName("CVE-2018-19362")
+                        .setSeverity("CRITICAL")
+                        .setCwes("CWE-502")
+                        .setDescription("FasterXML jackson-databind 2.x before 2.9.8 might allow attackers to have unspecified impact by leveraging failure to block the jboss-common-core class from polymorphic deserialization.")
+                        .setFileName("jackson-databind-2.9.3.jar")));
         expected.stream().forEach(entry -> assertTrue(vulnerabilities.contains(entry)));
     }
 

--- a/src/test/java/org/sonar/plugins/clojure/sensors/leinnvd/LeinNvdSensorTest.java
+++ b/src/test/java/org/sonar/plugins/clojure/sensors/leinnvd/LeinNvdSensorTest.java
@@ -60,12 +60,12 @@ public class LeinNvdSensorTest {
 
         List<Issue> issuesList = new ArrayList<>(context.allIssues());
         assertThat(issuesList.size(), is(2));
-        assertThat(issuesList.get(0).ruleKey().rule(), is("nvd-medium"));
+        assertThat(issuesList.get(0).ruleKey().rule(), is("nvd-high"));
         assertThat(issuesList.get(0).primaryLocation().message(),
-                is("CVE-2017-7656;CWE-284 Improper Access Control;jetty-util-9.2.21.v20170120.jar"));
-        assertThat(issuesList.get(1).ruleKey().rule(), is("nvd-high"));
+                is("CVE-2018-5968;CWE-502,CWE-184;jackson-databind-2.9.3.jar"));
+        assertThat(issuesList.get(1).ruleKey().rule(), is("nvd-critical"));
         assertThat(issuesList.get(1).primaryLocation().message(),
-                is("CVE-2017-7657;CWE-190 Integer Overflow or Wraparound;jetty-util-9.2.21.v20170120.jar"));
+                is("CVE-2018-19362;CWE-502;jackson-databind-2.9.3.jar"));
     }
 
     private SensorContextTester prepareContext() throws IOException {

--- a/src/test/resources/nvd-report.json
+++ b/src/test/resources/nvd-report.json
@@ -2,19 +2,19 @@
   "reportSchema": "1.1",
   "dependencies": [
     {
-      "fileName": "jetty-util-9.2.21.v20170120.jar",
+      "fileName": "jackson-databind-2.9.3.jar",
       "vulnerabilities": [
         {
-          "name": "CVE-2017-7656",
-          "severity": "Medium",
-          "cwe": "CWE-284 Improper Access Control",
-          "description": "In Eclipse Jetty, versions 9.2.x and older, 9.3.x (all configurations), and 9.4.x (non-default configuration with RFC2616 compliance enabled), HTTP/0.9 is handled poorly. An HTTP/1 style request line (i.e. method space URI space version) that declares a version of HTTP/0.9 was accepted and treated as a 0.9 request. If deployed behind an intermediary that also accepted and passed through the 0.9 version (but did not act on it), then the response sent could be interpreted by the intermediary as HTTP/1 headers. This could be used to poison the cache if the server allowed the origin client to generate arbitrary content in the response."
+          "name": "CVE-2018-5968",
+          "severity": "HIGH",
+          "cwes": ["CWE-502", "CWE-184"],
+          "description": "FasterXML jackson-databind through 2.8.11 and 2.9.x through 2.9.3 allows unauthenticated remote code execution because of an incomplete fix for the CVE-2017-7525 and CVE-2017-17485 deserialization flaws. This is exploitable via two different gadgets that bypass a blacklist."
         },
         {
-          "name": "CVE-2017-7657",
-          "severity": "High",
-          "cwe": "CWE-190 Integer Overflow or Wraparound",
-          "description": "In Eclipse Jetty, versions 9.2.x and older, 9.3.x (all configurations), and 9.4.x (non-default configuration with RFC2616 compliance enabled), transfer-encoding chunks are handled poorly. The chunk length parsing was vulnerable to an integer overflow. Thus a large chunk size could be interpreted as a smaller chunk size and content sent as chunk body could be interpreted as a pipelined request. If Jetty was deployed behind an intermediary that imposed some authorization and that intermediary allowed arbitrarily large chunks to be passed on unchanged, then this flaw could be used to bypass the authorization imposed by the intermediary as the fake pipelined request would not be interpreted by the intermediary as a request."
+          "name": "CVE-2018-19362",
+          "severity": "CRITICAL",
+          "cwes": ["CWE-502"],
+          "description": "FasterXML jackson-databind 2.x before 2.9.8 might allow attackers to have unspecified impact by leveraging failure to block the jboss-common-core class from polymorphic deserialization."
         }
       ]
     },


### PR DESCRIPTION
The report generated on NVD has changed. The `cwe` key that used to hold the string in the report has changed to an array of strings held by `cwes`. 

This commit fixes the issue reported - https://github.com/fsantiag/sonar-clojure/issues/34