### PR TITLE
Clj kondo integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ In order to install SonarClojure:
 3. Restart the SonarQube server.
 
 ## Usage
-1. Change your ***project.clj*** file and add the required plugins:
+1. Change your ***project.clj*** file and add the required plugins and/or dependencies:
 
     ```clojure
     :plugins [[jonase/eastwood "0.3.6"]
@@ -30,8 +30,9 @@ In order to install SonarClojure:
               [lein-ancient "0.6.15"]
               [lein-cloverage "1.1.2"]
               [lein-nvd "1.4.0"]]
+    :dependencies [[clj-kondo "RELEASE"]]
      ```
-
+   
 > Note 1: Please make sure the plugins above are setup correctly for your project. A good way to test this is to
 execute each one of them individually on your project. Once they are running fine, SonarClojure should be able to
 parse their reports.
@@ -55,7 +56,7 @@ version, keep in mind that it might cause errors on SonarClojure analysis.
 #### Disabling
 Sensors can be disabled by setting `sonar.clojure.<sensorname>.disabled=true` in the sonar-project.properties or
 by using the command line argument `-Dsonar.clojure.<sensorname>.disabled` when running sonar-scanner.
-Sensor names are `eastwood`, `kibit`, `ancient`, `nvd` and `cloverage`.
+Sensor names are `eastwood`, `kibit`, `clj-kondo`, `ancient`, `nvd` and `cloverage`.
 
 #### Report file location
 Some sensors use report files to parse the results. Both cloverage and lein-nvd use this report files.

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,11 @@
             <artifactId>gson</artifactId>
             <version>2.8.4</version>
         </dependency>
+        <dependency>
+            <groupId>us.bpsm</groupId>
+            <artifactId>edn-java</artifactId>
+            <version>0.6.0</version>
+        </dependency>
     </dependencies>
 
     <properties>
@@ -66,4 +71,12 @@
             </plugin>
         </plugins>
     </build>
+
+    <repositories>
+        <repository>
+            <id>sonatype</id>
+            <name>Sonatype</name>
+            <url>https://oss.sonatype.org/content/repositories/releases</url>
+        </repository>
+    </repositories>
 </project>

--- a/src/main/java/org/sonar/plugins/clojure/ClojurePlugin.java
+++ b/src/main/java/org/sonar/plugins/clojure/ClojurePlugin.java
@@ -9,6 +9,7 @@ import org.sonar.plugins.clojure.sensors.ancient.AncientSensor;
 import org.sonar.plugins.clojure.sensors.cloverage.CloverageSensor;
 import org.sonar.plugins.clojure.sensors.eastwood.EastwoodSensor;
 import org.sonar.plugins.clojure.sensors.kibit.KibitSensor;
+import org.sonar.plugins.clojure.sensors.kondo.KondoSensor;
 import org.sonar.plugins.clojure.sensors.leinnvd.LeinNvdSensor;
 import org.sonar.plugins.clojure.settings.Properties;
 
@@ -26,5 +27,6 @@ public class ClojurePlugin implements Plugin {
         context.addExtension(AncientSensor.class);
         context.addExtension(CloverageSensor.class);
         context.addExtension(LeinNvdSensor.class);
+        context.addExtension(KondoSensor.class);
     }
 }

--- a/src/main/java/org/sonar/plugins/clojure/sensors/kondo/Finding.java
+++ b/src/main/java/org/sonar/plugins/clojure/sensors/kondo/Finding.java
@@ -1,0 +1,49 @@
+package org.sonar.plugins.clojure.sensors.kondo;
+
+public class Finding {
+    private String type, message, filename, level;
+    private int row, col, endRow, endCol;
+
+    public Finding(String type, String message, String filename, String level, int row, int col, int endRow, int endCol) {
+        this.type = type;
+        this.message = message;
+        this.filename = filename;
+        this.level = level;
+        this.row = row;
+        this.col = col;
+        this.endRow = endRow;
+        this.endCol = endCol;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getFilename() {
+        return filename;
+    }
+
+    public int getRow() {
+        return row;
+    }
+
+    public int getCol() {
+        return col;
+    }
+
+    public int getEndRow() {
+        return endRow;
+    }
+
+    public int getEndCol() {
+        return endCol;
+    }
+
+    public String getLevel() {
+        return level;
+    }
+}

--- a/src/main/java/org/sonar/plugins/clojure/sensors/kondo/KondoIssueParser.java
+++ b/src/main/java/org/sonar/plugins/clojure/sensors/kondo/KondoIssueParser.java
@@ -1,11 +1,13 @@
 package org.sonar.plugins.clojure.sensors.kondo;
 
+import org.sonar.api.internal.google.common.collect.Lists;
 import org.sonar.plugins.clojure.sensors.CommandStreamConsumer;
 import us.bpsm.edn.Keyword;
 import us.bpsm.edn.parser.Parseable;
 import us.bpsm.edn.parser.Parser;
 import us.bpsm.edn.parser.Parsers;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -15,6 +17,9 @@ import static us.bpsm.edn.parser.Parsers.defaultConfiguration;
 
 public class KondoIssueParser {
     public static List<Finding> parse(CommandStreamConsumer stdOut) {
+        if (stdOut == null){
+            return Collections.EMPTY_LIST;
+        }
         String kondoOutput = String.join("", stdOut.getData());
 
         Parseable parseable = Parsers.newParseable(kondoOutput);

--- a/src/main/java/org/sonar/plugins/clojure/sensors/kondo/KondoIssueParser.java
+++ b/src/main/java/org/sonar/plugins/clojure/sensors/kondo/KondoIssueParser.java
@@ -1,0 +1,45 @@
+package org.sonar.plugins.clojure.sensors.kondo;
+
+import org.sonar.plugins.clojure.sensors.CommandStreamConsumer;
+import us.bpsm.edn.Keyword;
+import us.bpsm.edn.parser.Parseable;
+import us.bpsm.edn.parser.Parser;
+import us.bpsm.edn.parser.Parsers;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static us.bpsm.edn.Keyword.newKeyword;
+import static us.bpsm.edn.parser.Parsers.defaultConfiguration;
+
+public class KondoIssueParser {
+    public static List<Finding> parse(CommandStreamConsumer stdOut) {
+        String kondoOutput = String.join("", stdOut.getData());
+
+        Parseable parseable = Parsers.newParseable(kondoOutput);
+        Parser parser = Parsers.newParser(defaultConfiguration());
+
+        Map<?, ?> m = (Map<?, ?>) parser.nextValue(parseable);
+
+        List<Object> findings = (List<Object>) m.get(newKeyword("findings"));
+
+        return findings.stream()
+                .map(f -> asFinding((Map<?, ?>) f))
+                .collect(Collectors.toList());
+    }
+
+    private static Finding asFinding(Map<?, ?> finding) {
+        Keyword typeKw = (Keyword) finding.get(newKeyword("type"));
+        String message = (String) finding.get(newKeyword("message"));
+        String filename = (String) finding.get(newKeyword("filename"));
+        String level = ((Keyword) finding.get(newKeyword("level"))).getName();
+        Long row = (Long) finding.get(newKeyword("row"));
+        Long col = (Long) finding.get(newKeyword("col"));
+        Long endRow = (Long) finding.get(newKeyword("end-row"));
+        Long endCol = (Long) finding.get(newKeyword("end-col"));
+
+        return new Finding(typeKw.getName(), message, filename, level,
+                row.intValue(), col.intValue(), endRow.intValue(), endCol.intValue());
+    }
+}

--- a/src/main/java/org/sonar/plugins/clojure/sensors/kondo/KondoSensor.java
+++ b/src/main/java/org/sonar/plugins/clojure/sensors/kondo/KondoSensor.java
@@ -1,0 +1,103 @@
+package org.sonar.plugins.clojure.sensors.kondo;
+
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.fs.TextRange;
+import org.sonar.api.batch.rule.Severity;
+import org.sonar.api.batch.sensor.Sensor;
+import org.sonar.api.batch.sensor.SensorContext;
+import org.sonar.api.batch.sensor.SensorDescriptor;
+import org.sonar.api.batch.sensor.issue.NewIssue;
+import org.sonar.api.batch.sensor.issue.NewIssueLocation;
+import org.sonar.api.rule.RuleKey;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
+import org.sonar.plugins.clojure.language.ClojureLanguage;
+import org.sonar.plugins.clojure.rules.ClojureLintRulesDefinition;
+import org.sonar.plugins.clojure.sensors.AbstractSensor;
+import org.sonar.plugins.clojure.sensors.CommandRunner;
+import org.sonar.plugins.clojure.sensors.CommandStreamConsumer;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.sonar.plugins.clojure.settings.KondoProperties.DISABLED_PROPERTY;
+import static org.sonar.plugins.clojure.settings.KondoProperties.DISABLED_PROPERTY_DEFAULT;
+import static org.sonar.plugins.clojure.settings.Properties.SENSORS_TIMEOUT_PROPERTY;
+import static org.sonar.plugins.clojure.settings.Properties.SENSORS_TIMEOUT_PROPERTY_DEFAULT;
+
+public class KondoSensor extends AbstractSensor implements Sensor {
+
+    private static final Logger LOG = Loggers.get(KondoSensor.class);
+
+    private static final String PLUGIN_NAME = "clj-kondo";
+    private static final String[] COMMAND =
+            {"with-profile", "analysis", "run", "-m", "clj-kondo.main", "--lint", "src", "--config", "{:output {:format :edn}}"};
+
+    public KondoSensor(CommandRunner commandRunner) {
+        super(commandRunner);
+    }
+
+    @Override
+    public void describe(SensorDescriptor descriptor) {
+        descriptor.name(PLUGIN_NAME)
+                .onlyOnLanguage(ClojureLanguage.KEY)
+                .global();
+    }
+
+    private void saveIssue(Finding finding, SensorContext context) {
+        String filename = finding.getFilename();
+        try {
+            Optional<InputFile> fileOptional = getFile(filename, context.fileSystem());
+
+            if (fileOptional.isPresent()) {
+                InputFile file = fileOptional.get();
+                RuleKey ruleKey = RuleKey.of(ClojureLintRulesDefinition.REPOSITORY_KEY, finding.getType());
+
+                NewIssue newIssue = context.newIssue().forRule(ruleKey);
+
+                NewIssueLocation primaryLocation = newIssue
+                        .newLocation()
+                        .on(file)
+                        .message(finding.getMessage());
+
+                TextRange range = file.newRange(finding.getRow(), finding.getCol(),
+                        finding.getEndRow(), finding.getEndCol());
+                primaryLocation.at(range);
+
+                newIssue.at(primaryLocation);
+                newIssue.overrideSeverity(getSeverity(finding.getLevel()));
+                newIssue.save();
+            } else {
+                LOG.warn("Not able to find a file with path '{}'", filename);
+            }
+        } catch (Exception e) {
+            LOG.error("Can not save the issue due to: " + e.getMessage());
+        }
+    }
+
+    private Severity getSeverity(String level) {
+        switch (level) {
+            case "info": return Severity.INFO;
+            case "warning": return Severity.MINOR;
+            case "error": return Severity.MAJOR;
+            default: return null;
+        }
+    }
+
+    @Override
+    public void execute(SensorContext context) {
+        if (!isPluginDisabled(context, PLUGIN_NAME, DISABLED_PROPERTY, DISABLED_PROPERTY_DEFAULT)) {
+            LOG.info("Running clj-kondo");
+            long timeOut = context.config().getLong(SENSORS_TIMEOUT_PROPERTY)
+                    .orElse(Long.valueOf(SENSORS_TIMEOUT_PROPERTY_DEFAULT));
+
+            CommandStreamConsumer stdOut = this.commandRunner.run(timeOut, LEIN_COMMAND, COMMAND);
+
+            List<Finding> issues = KondoIssueParser.parse(stdOut);
+            LOG.info("Saving issues " + issues.size());
+            for (Finding finding : issues) {
+                saveIssue(finding, context);
+            }
+        }
+    }
+}

--- a/src/main/java/org/sonar/plugins/clojure/sensors/kondo/KondoSensor.java
+++ b/src/main/java/org/sonar/plugins/clojure/sensors/kondo/KondoSensor.java
@@ -11,7 +11,7 @@ import org.sonar.api.batch.sensor.issue.NewIssueLocation;
 import org.sonar.api.rule.RuleKey;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
-import org.sonar.plugins.clojure.language.ClojureLanguage;
+import org.sonar.plugins.clojure.language.Clojure;
 import org.sonar.plugins.clojure.rules.ClojureLintRulesDefinition;
 import org.sonar.plugins.clojure.sensors.AbstractSensor;
 import org.sonar.plugins.clojure.sensors.CommandRunner;
@@ -40,7 +40,7 @@ public class KondoSensor extends AbstractSensor implements Sensor {
     @Override
     public void describe(SensorDescriptor descriptor) {
         descriptor.name(PLUGIN_NAME)
-                .onlyOnLanguage(ClojureLanguage.KEY)
+                .onlyOnLanguage(Clojure.KEY)
                 .global();
     }
 

--- a/src/main/java/org/sonar/plugins/clojure/sensors/kondo/KondoSensor.java
+++ b/src/main/java/org/sonar/plugins/clojure/sensors/kondo/KondoSensor.java
@@ -93,7 +93,7 @@ public class KondoSensor extends AbstractSensor implements Sensor {
             LOG.info("Running clj-kondo");
 
             String config = context.config().get(CONFIG).orElse(null);
-            String[] options = context.config().get(OPTIONS).orElse("").split("\\W+");
+            String[] options = context.config().get(OPTIONS).orElse("").split("\\s+");
             List<String> commandAsList = new ArrayList(Arrays.asList(COMMAND));
             commandAsList.addAll(Arrays.asList(options));
             if (config != null && !config.isEmpty()) {

--- a/src/main/java/org/sonar/plugins/clojure/settings/KondoProperties.java
+++ b/src/main/java/org/sonar/plugins/clojure/settings/KondoProperties.java
@@ -11,6 +11,8 @@ import static org.sonar.plugins.clojure.settings.Properties.SUB_CATEGORY;
 
 public class KondoProperties {
     public static final String DISABLED_PROPERTY = "sonar.clojure.kondo.disabled";
+    public static final String OPTIONS = "sonar.clojure.kondo.options";
+    public static final String CONFIG = "sonar.clojure.kondo.config";
     public static final boolean DISABLED_PROPERTY_DEFAULT = true;
 
     private KondoProperties() {
@@ -26,8 +28,27 @@ public class KondoProperties {
                 .build();
     }
 
-    static List<PropertyDefinition> getProperties() {
-        return asList(getDisabledProperty());
+    static PropertyDefinition getOptionsProperty() {
+        return PropertyDefinition.builder(OPTIONS)
+                .category(MAIN_CATEGORY)
+                .subCategory(SUB_CATEGORY)
+                .defaultValue("--lint src")
+                .name("clj-kondo options")
+                .description("Provide options for clj-kondo plugin (e.g --lint src)")
+                .build();
     }
 
+    static PropertyDefinition getConfigProperty() {
+        return PropertyDefinition.builder(CONFIG)
+                .category(MAIN_CATEGORY)
+                .subCategory(SUB_CATEGORY)
+                .defaultValue("{:output {:format :edn}}")
+                .name("clj-kondo config")
+                .description("Provide config for clj-kondo plugin (e.g {:output {:format :edn}})")
+                .build();
+    }
+
+    static List<PropertyDefinition> getProperties() {
+        return asList(getDisabledProperty(), getOptionsProperty(), getConfigProperty());
+    }
 }

--- a/src/main/java/org/sonar/plugins/clojure/settings/KondoProperties.java
+++ b/src/main/java/org/sonar/plugins/clojure/settings/KondoProperties.java
@@ -1,0 +1,33 @@
+package org.sonar.plugins.clojure.settings;
+
+import org.sonar.api.config.PropertyDefinition;
+
+import java.util.List;
+
+import static java.lang.String.valueOf;
+import static java.util.Arrays.asList;
+import static org.sonar.plugins.clojure.settings.Properties.MAIN_CATEGORY;
+import static org.sonar.plugins.clojure.settings.Properties.SUB_CATEGORY;
+
+public class KondoProperties {
+    public static final String DISABLED_PROPERTY = "sonar.clojure.kondo.disabled";
+    public static final boolean DISABLED_PROPERTY_DEFAULT = true;
+
+    private KondoProperties() {
+    }
+
+    static PropertyDefinition getDisabledProperty() {
+        return PropertyDefinition.builder(DISABLED_PROPERTY)
+                .category(MAIN_CATEGORY)
+                .subCategory(SUB_CATEGORY)
+                .defaultValue(valueOf(DISABLED_PROPERTY_DEFAULT))
+                .name("clj-kondo disabled")
+                .description("Indicates if clj-kondo sensor should be disabled")
+                .build();
+    }
+
+    static List<PropertyDefinition> getProperties() {
+        return asList(getDisabledProperty());
+    }
+
+}

--- a/src/main/java/org/sonar/plugins/clojure/settings/Properties.java
+++ b/src/main/java/org/sonar/plugins/clojure/settings/Properties.java
@@ -28,7 +28,8 @@ public class Properties {
                     CloverageProperties.getProperties(),
                     AncientProperties.getProperties(),
                     KibitProperties.getProperties(),
-                    NvdProperties.getProperties())
+                    NvdProperties.getProperties(),
+                    KondoProperties.getProperties())
                 .flatMap(Collection::stream)
                 .collect(Collectors.toList());
     }

--- a/src/main/resources/clojure/rules.xml
+++ b/src/main/resources/clojure/rules.xml
@@ -408,96 +408,84 @@
         <key>unused-binding</key>
         <name>unused-binding</name>
         <internalKey>unused-binding</internalKey>
-        <description>clj-kondo linting rule
-        </description>
+        <description>warn on unused binding</description>
         <type>CODE_SMELL</type>
     </rule>
     <rule>
         <key>refer-all</key>
         <name>refer-all</name>
         <internalKey>refer-all</internalKey>
-        <description>clj-kondo linting rule
-        </description>
+        <description>warns when :refer :all is used</description>
         <type>CODE_SMELL</type>
     </rule>
     <rule>
         <key>unresolved-symbol</key>
         <name>unresolved-symbol</name>
         <internalKey>unresolved-symbol</internalKey>
-        <description>clj-kondo linting rule
-        </description>
+        <description>warn on unresolved symbols</description>
         <type>CODE_SMELL</type>
     </rule>
     <rule>
         <key>type-mismatch</key>
         <name>type-mismatch</name>
         <internalKey>type-mismatch</internalKey>
-        <description>clj-kondo linting rule
-        </description>
+        <description>warn on type mismatches, e.g. passing a keyword where a number is expected</description>
         <type>BUG</type>
     </rule>
     <rule>
         <key>unused-namespace</key>
         <name>unused-namespace</name>
         <internalKey>unused-namespace</internalKey>
-        <description>clj-kondo linting rule
-        </description>
+        <description>warns on required but unused namespace</description>
         <type>CODE_SMELL</type>
     </rule>
     <rule>
         <key>invalid-arity</key>
         <name>invalid-arity</name>
         <internalKey>invalid-arity</internalKey>
-        <description>clj-kondo linting rule
-        </description>
+        <description>warn when a function (or macro) is called with an invalid amount of arguments</description>
         <type>BUG</type>
     </rule>
     <rule>
         <key>not-a-function</key>
         <name>not-a-function</name>
         <internalKey>not-a-function</internalKey>
-        <description>clj-kondo linting rule
-        </description>
+        <description>clj-kondo linting rule</description>
         <type>BUG</type>
     </rule>
     <rule>
         <key>private-call</key>
         <name>private-call</name>
         <internalKey>private-call</internalKey>
-        <description>clj-kondo linting rule
-        </description>
+        <description>warn when private var is used. The name of this linter should be renamed to "private usage" since it will warn on usage of private vars and not only inside calls</description>
         <type>BUG</type>
     </rule>
     <rule>
         <key>inline-def</key>
         <name>inline-def</name>
         <internalKey>inline-def</internalKey>
-        <description>clj-kondo linting rule
-        </description>
+        <description>warn on non-toplevel usage of def (and defn, etc.)</description>
         <type>CODE_SMELL</type>
     </rule>
     <rule>
         <key>redundant-do</key>
         <name>redundant-do</name>
         <internalKey>redundant-do</internalKey>
-        <description>clj-kondo linting rule
-        </description>
+        <description>warn on usage of do that is redundant. The warning usually arises because of an explicit or implicit do as the direct parent s-expression</description>
         <type>CODE_SMELL</type>
     </rule>
     <rule>
         <key>cond-else</key>
         <name>cond-else</name>
         <internalKey>cond-else</internalKey>
-        <description>clj-kondo linting rule
-        </description>
+        <description>warn on cond with a different constant for the else branch than :else</description>
         <type>CODE_SMELL</type>
     </rule>
     <rule>
         <key>syntax</key>
         <name>syntax</name>
         <internalKey>syntax</internalKey>
-        <description>clj-kondo linting rule
-        </description>
+        <description>warn on invalid syntax</description>
         <type>BUG</type>
     </rule>
 

--- a/src/main/resources/clojure/rules.xml
+++ b/src/main/resources/clojure/rules.xml
@@ -404,4 +404,101 @@
         <remediationFunction>CONSTANT_ISSUE</remediationFunction>
         <remediationFunctionBaseEffort>60min</remediationFunctionBaseEffort>◊
     </rule>
+    <rule>
+        <key>unused-binding</key>
+        <name>unused-binding</name>
+        <internalKey>unused-binding</internalKey>
+        <description>clj-kondo linting rule
+        </description>
+        <type>CODE_SMELL</type>
+    </rule>
+    <rule>
+        <key>refer-all</key>
+        <name>refer-all</name>
+        <internalKey>refer-all</internalKey>
+        <description>clj-kondo linting rule
+        </description>
+        <type>CODE_SMELL</type>
+    </rule>
+    <rule>
+        <key>unresolved-symbol</key>
+        <name>unresolved-symbol</name>
+        <internalKey>unresolved-symbol</internalKey>
+        <description>clj-kondo linting rule
+        </description>
+        <type>CODE_SMELL</type>
+    </rule>
+    <rule>
+        <key>type-mismatch</key>
+        <name>type-mismatch</name>
+        <internalKey>type-mismatch</internalKey>
+        <description>clj-kondo linting rule
+        </description>
+        <type>BUG</type>
+    </rule>
+    <rule>
+        <key>unused-namespace</key>
+        <name>unused-namespace</name>
+        <internalKey>unused-namespace</internalKey>
+        <description>clj-kondo linting rule
+        </description>
+        <type>CODE_SMELL</type>
+    </rule>
+    <rule>
+        <key>invalid-arity</key>
+        <name>invalid-arity</name>
+        <internalKey>invalid-arity</internalKey>
+        <description>clj-kondo linting rule
+        </description>
+        <type>BUG</type>
+    </rule>
+    <rule>
+        <key>not-a-function</key>
+        <name>not-a-function</name>
+        <internalKey>not-a-function</internalKey>
+        <description>clj-kondo linting rule
+        </description>
+        <type>BUG</type>
+    </rule>
+    <rule>
+        <key>private-call</key>
+        <name>private-call</name>
+        <internalKey>private-call</internalKey>
+        <description>clj-kondo linting rule
+        </description>
+        <type>BUG</type>
+    </rule>
+    <rule>
+        <key>inline-def</key>
+        <name>inline-def</name>
+        <internalKey>inline-def</internalKey>
+        <description>clj-kondo linting rule
+        </description>
+        <type>CODE_SMELL</type>
+    </rule>
+    <rule>
+        <key>redundant-do</key>
+        <name>redundant-do</name>
+        <internalKey>redundant-do</internalKey>
+        <description>clj-kondo linting rule
+        </description>
+        <type>CODE_SMELL</type>
+    </rule>
+    <rule>
+        <key>cond-else</key>
+        <name>cond-else</name>
+        <internalKey>cond-else</internalKey>
+        <description>clj-kondo linting rule
+        </description>
+        <type>CODE_SMELL</type>
+    </rule>
+    <rule>
+        <key>syntax</key>
+        <name>syntax</name>
+        <internalKey>syntax</internalKey>
+        <description>clj-kondo linting rule
+        </description>
+        <type>BUG</type>
+    </rule>
+
 </rules>

--- a/src/main/resources/clojure/sonar_way.json
+++ b/src/main/resources/clojure/sonar_way.json
@@ -29,6 +29,18 @@
     "wrong-arity",
     "wrong-ns-form",
     "wrong-pre-post",
-    "wrong-tag"
+    "wrong-tag",
+    "unused-binding",
+    "refer-all",
+    "unresolved-symbol",
+    "type-mismatch",
+    "unused-namespace",
+    "invalid-arity",
+    "not-a-function",
+    "private-call",
+    "inline-def",
+    "redundant-do",
+    "cond-else",
+    "syntax"
   ]
 }

--- a/src/test/java/org/sonar/plugins/clojure/sensors/kondo/KondoIssueParserTest.java
+++ b/src/test/java/org/sonar/plugins/clojure/sensors/kondo/KondoIssueParserTest.java
@@ -1,0 +1,48 @@
+package org.sonar.plugins.clojure.sensors.kondo;
+
+import org.junit.Test;
+import org.sonar.plugins.clojure.sensors.CommandStreamConsumer;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class KondoIssueParserTest {
+
+    @Test
+    public void testNoIssuesGeneratedForInvalidStreamConsumer() {
+        CommandStreamConsumer output = new CommandStreamConsumer();
+        output.consumeLine("{:findings [], :summary {:error 0, :warning 0, :info 0, :type :summary, :duration 173, :files 32}}");
+        List<Finding> issues = KondoIssueParser.parse(output);
+        assertThat(issues.size(), is(0));
+    }
+
+    @Test
+    public void testIssueGenerateForValidStreamConsumer() {
+        CommandStreamConsumer output = new CommandStreamConsumer();
+        output.consumeLine(
+                "{:findings [{:type :redundant-let, :message \"Redundant let expression.\", :level :warning, " +
+                        ":row 35, :end-row 36, :end-col 15, :col 5, :filename \"src/example/init.clj\"}], " +
+                        ":summary {:error 0, :warning 1, :info 0, :type :summary, :duration 157, :files 32}}");
+
+        List<Finding> issues = KondoIssueParser.parse(output);
+
+        assertThat(issues.size(), is(1));
+        assertThat(issues.get(0).getMessage(), is("Redundant let expression."));
+        assertThat(issues.get(0).getType(), is("redundant-let"));
+        assertThat(issues.get(0).getFilename(), is("src/example/init.clj"));
+        assertThat(issues.get(0).getLevel(), is("warning"));
+        assertThat(issues.get(0).getCol(), is(5));
+        assertThat(issues.get(0).getEndCol(), is(15));
+        assertThat(issues.get(0).getRow(), is(35));
+        assertThat(issues.get(0).getEndRow(), is(36));
+    }
+
+    @Test
+    public void testNoIssuesGeneratedForNullStreamConsumer() {
+        CommandStreamConsumer output = null;
+        List<Finding> issues = KondoIssueParser.parse(output);
+        assertThat(issues.size(), is(0));
+    }
+}

--- a/src/test/java/org/sonar/plugins/clojure/sensors/kondo/KondoSensorTest.java
+++ b/src/test/java/org/sonar/plugins/clojure/sensors/kondo/KondoSensorTest.java
@@ -1,0 +1,89 @@
+package org.sonar.plugins.clojure.sensors.kondo;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.sonar.api.batch.fs.internal.DefaultInputFile;
+import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
+import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
+import org.sonar.api.batch.sensor.internal.SensorContextTester;
+import org.sonar.api.batch.sensor.issue.Issue;
+import org.sonar.plugins.clojure.language.Clojure;
+import org.sonar.plugins.clojure.sensors.CommandRunner;
+import org.sonar.plugins.clojure.sensors.CommandStreamConsumer;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.sonar.plugins.clojure.settings.KondoProperties.OPTIONS;
+import static org.sonar.plugins.clojure.settings.KondoProperties.CONFIG;
+import static org.sonar.plugins.clojure.settings.KondoProperties.DISABLED_PROPERTY;
+
+public class KondoSensorTest {
+
+    @Mock
+    private CommandRunner commandRunner;
+
+    private KondoSensor kondoSensor;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        kondoSensor = new KondoSensor(commandRunner);
+    }
+
+    @Test
+    public void shouldConfigureSensor() {
+        DefaultSensorDescriptor descriptor = new DefaultSensorDescriptor();
+        kondoSensor.describe(descriptor);
+        assertThat(descriptor.name(), is("clj-kondo"));
+        assertTrue(descriptor.languages().contains("clj"));
+        assertThat(descriptor.languages().size(), is(1));
+    }
+
+    @Test
+    public void shouldExecuteKondo() throws IOException {
+        SensorContextTester context = prepareContext();
+
+        CommandStreamConsumer stdOut = new CommandStreamConsumer();
+        stdOut.consumeLine("{:findings [{:type :unused-binding, :filename \"file.clj\", " +
+                ":message \"unused binding args\", :row 1, :col 16, :end-row 1, :end-col 20, :level :warning}], " +
+                ":summary {:error 0, :warning 1, :info 0, :type :summary, :duration 11, :files 1}}\n");
+        when(commandRunner.run(300L, "lein", "run", "-m", "clj-kondo.main", "--lint", "src", "--config", "{:output {:format :edn}}"))
+                .thenReturn(stdOut);
+
+        kondoSensor.execute(context);
+
+        List<Issue> issuesList = new ArrayList<>(context.allIssues());
+        assertThat(issuesList.size(), is(1));
+        assertThat(issuesList.get(0).ruleKey().rule(), is("unused-binding"));
+        assertThat(issuesList.get(0).primaryLocation().message(), is("unused binding args"));
+    }
+
+    private SensorContextTester prepareContext() throws IOException {
+        SensorContextTester context = SensorContextTester.create(new File("src/test/resources/"));
+
+        context.settings().appendProperty(OPTIONS, "--lint src");
+        context.settings().appendProperty(CONFIG, "{:output {:format :edn}}");
+        context.settings().appendProperty(DISABLED_PROPERTY, "false");
+
+        File baseDir = new File("src/test/resources/");
+        File file = new File(baseDir, "file.clj");
+        DefaultInputFile inputFile = TestInputFileBuilder.create("", "file.clj")
+                .setLanguage(Clojure.KEY)
+                .initMetadata(new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8))
+                .build();
+        context.fileSystem().add(inputFile);
+
+        return context;
+    }
+}


### PR DESCRIPTION
Added support of modern [clj-kondo](https://github.com/borkdude/clj-kondo) linter. 
The output format of the `clj-kondo` linter must be EDN. It is configurable in `sonar.clojure.kondo.config` property.

Two properties can be used, the default values is the following:
- `sonar.clojure.kondo.options=--lint src`
- `sonar.clojure.kondo.config={:output {:format :edn}}`