### PR TITLE
Typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ version, keep in mind that it might cause errors on SonarClojure analysis.
 #### Disabling
 Sensors can be disabled by setting `sonar.clojure.<sensorname>.enabled=false` in the sonar-project.properties or
 by using the command line argument `-Dsonar.clojure.<sensorname>.enabled` when running sonar-scanner.
-Sensor names are `eastwood`, `kibit`, `clj-kondo`, `ancient`, `nvd` and `cloverage`.
+Sensor names are `eastwood`, `kibit`, `kondo`, `ancient`, `nvd` and `cloverage`.
 
 #### Report file location
 Some sensors use report files to parse the results. Both cloverage and lein-nvd use this report files.


### PR DESCRIPTION
There is typo, actual clj-kondo name in properties is `kondo`
https://github.com/fsantiag/sonar-clojure/blob/07a1aba5aeb3544492ae8ef6bfbe06e72dd9fbc8/src/main/java/org/sonar/plugins/clojure/settings/KondoProperties.java#L13