### PR TITLE
Fix columns in Sonar reporting for clj-kondo

### DIFF
--- a/src/main/java/org/sonar/plugins/clojure/sensors/kondo/KondoSensor.java
+++ b/src/main/java/org/sonar/plugins/clojure/sensors/kondo/KondoSensor.java
@@ -60,8 +60,8 @@ public class KondoSensor extends AbstractSensor implements Sensor {
                         .on(file)
                         .message(finding.getMessage());
 
-                TextRange range = file.newRange(finding.getRow(), finding.getCol(),
-                        finding.getEndRow(), finding.getEndCol());
+                TextRange range = file.newRange(finding.getRow(), finding.getCol() - 1,
+                        finding.getEndRow(), finding.getEndCol() - 1);
                 primaryLocation.at(range);
 
                 newIssue.at(primaryLocation);

--- a/src/test/java/org/sonar/plugins/clojure/sensors/kondo/KondoSensorTest.java
+++ b/src/test/java/org/sonar/plugins/clojure/sensors/kondo/KondoSensorTest.java
@@ -5,7 +5,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.sonar.api.batch.fs.TextRange;
 import org.sonar.api.batch.fs.internal.DefaultInputFile;
+import org.sonar.api.batch.fs.internal.DefaultTextPointer;
+import org.sonar.api.batch.fs.internal.DefaultTextRange;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
@@ -61,10 +64,13 @@ public class KondoSensorTest {
 
         kondoSensor.execute(context);
 
+        TextRange expectedRange = new DefaultTextRange(new DefaultTextPointer(1, 15), new DefaultTextPointer(1, 19));
+
         List<Issue> issuesList = new ArrayList<>(context.allIssues());
         assertThat(issuesList.size(), is(1));
         assertThat(issuesList.get(0).ruleKey().rule(), is("kondo"));
         assertThat(issuesList.get(0).primaryLocation().message(), is("unused binding args"));
+        assertThat(issuesList.get(0).primaryLocation().textRange(), is(expectedRange));
     }
 
     private SensorContextTester prepareContext() throws IOException {


### PR DESCRIPTION
It seems in Sonar column numeration starts from 0 instead of 1 as reported by clj-kondo.

This is observable from Sonar UI like:
<img width="230" alt="SonarUI" src="https://user-images.githubusercontent.com/3020103/109855159-a01ea680-7c60-11eb-8e75-b7f5516d3afe.png">

Also, it may lead to scanner errors like
```
##[error]ERROR: Can not save the issue due to: 15 is not a valid line offset for pointer. File src/lib/services/http_utils.clj has 14 character(s) at line 40
```