### PR TITLE
Do not advertise the plugin as SonarLint compatible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,6 @@
                     <pluginKey>clojure</pluginKey>
                     <pluginClass>org.sonar.plugins.clojure.ClojurePlugin</pluginClass>
                     <pluginName>SonarClojure</pluginName>
-                    <sonarLintSupported>true</sonarLintSupported>
                     <sonarQubeMinVersion>7.9</sonarQubeMinVersion>
                 </configuration>
             </plugin>


### PR DESCRIPTION
SonarLint only supports SonarSource analyzers. Having this plugin marked as SonarLint compatible will waste users bandwidth, since SonarLint will download the plugin but not actually run the Sensor.
Also, SonarLint doesn't implement the entire SonarQube plugin API, so this can lead to unexpected errors, like:
https://community.sonarsource.com/t/error-in-sonarlint-for-intellij-unable-to-extract-rules-metadata/57403